### PR TITLE
fix: onboard downloading stuck; seed data every startup; set current …

### DIFF
--- a/lib/core/extension/duration_ext.dart
+++ b/lib/core/extension/duration_ext.dart
@@ -1,5 +1,7 @@
 extension DurationExt on Duration {
   String formatDuration() {
+    if (isNegative) return 'Estimating';
+
     if (inHours > 0) {
       return '''$inHours hour${inHours > 1 ? 's' : ''} ${inMinutes.remainder(60)} minute${inMinutes.remainder(60) > 1 ? 's' : ''}''';
     } else if (inMinutes > 0) {

--- a/lib/feature/llm/provider/pick_llm_provider.dart
+++ b/lib/feature/llm/provider/pick_llm_provider.dart
@@ -28,6 +28,14 @@ class PickLlm extends _$PickLlm {
       return;
     }
 
+    final duplicate =
+        await ref.read(llmRepositoryProvider).getLlmModel(id: file.name);
+
+    if (duplicate.isSuccess) {
+      state = AsyncError(Exception('existed'), StackTrace.current);
+      return;
+    }
+
     final model = LlmModel(
       id: file.name,
       author: 'User',

--- a/lib/feature/llm/repository/llm_repository.dart
+++ b/lib/feature/llm/repository/llm_repository.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:simple_result/simple_result.dart';
 import 'package:synapse/app/constant/constant.dart';
@@ -30,6 +29,10 @@ final class LlmRepository {
 
   Future<Result<bool, Exception>> seedLlmModel() async {
     try {
+      final models = await _llmLDS.getLlmModels();
+
+      if (models.isNotEmpty) return const Result.success(true);
+
       final data = await _jsonLlmLDS.getLlmModels();
 
       await _llmLDS.createLlmModels(data: data);
@@ -66,16 +69,7 @@ final class LlmRepository {
       final kvp = await _kvpLDS.getKVP(Constant.kCurrentLLM);
 
       if (kvp == null) {
-        final models = await _llmLDS.getLlmModels();
-
-        final defaultModel =
-            models.firstWhereOrNull((element) => element.isAvailable);
-
-        if (defaultModel == null) return const Result.success(null);
-
-        await _kvpLDS.setKVP(Constant.kCurrentLLM, defaultModel.id!);
-
-        return Result.success(defaultModel);
+        return const Result.success(null);
       }
 
       final res = await _llmLDS.getLlmModel(llmId: kvp.value);

--- a/lib/feature/llm/widget/list_llm_container.dart
+++ b/lib/feature/llm/widget/list_llm_container.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:synapse/app/provider/current_llm/current_llm_provider.dart';
 import 'package:synapse/core/core.dart';
 import 'package:synapse/feature/conversation/conversation.dart';
 import 'package:synapse/feature/llm/provider/download_llm_provider.dart';
@@ -79,6 +80,8 @@ class ListLlmContainer extends ConsumerWidget {
             ref
                 .read(listLLMAsyncNotifierProvider.notifier)
                 .addLlmModel(data: next.value!);
+
+            ref.read(currentLlmProvider.notifier).setLlmModel(next.value!);
 
             context.go(ListConversationPage.route);
           }

--- a/lib/feature/onboard/widget/bottom_fake_chat.dart
+++ b/lib/feature/onboard/widget/bottom_fake_chat.dart
@@ -11,7 +11,7 @@ class BottomFakeChat extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.fromLTRB(8, 8, 4, 8),
+      padding: const EdgeInsets.fromLTRB(8, 8, 16, 8),
       decoration: BoxDecoration(
         color: context.shadColor.background,
         border: Border(top: BorderSide(color: context.shadColor.border)),
@@ -27,12 +27,11 @@ class BottomFakeChat extends StatelessWidget {
                   child: ChatInput(enabled: false),
                 ),
               ),
-              SizedBox(width: 16),
+              SizedBox(width: 12),
               Padding(
                 padding: EdgeInsets.only(bottom: 4),
                 child: ChatGenerating(),
               ),
-              SizedBox(width: 4),
             ],
           ),
           const SizedBox(height: 6),


### PR DESCRIPTION
…model onboard download finish

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fix downloading stuck when download and close app:

- Retrieve queued download task.
- Check if those tasks are resumable.
- If yes, resume them, else cancel them.
- Minor tweak on adding task Id to taskSet
Close #32 

Fix seed data every time open app. The data should be seeded only when LLM data is empty.

Fix does not set current LLM after download finishing in onboard page.

Fix some UIs

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
